### PR TITLE
Shellcheck clean up

### DIFF
--- a/git-fire
+++ b/git-fire
@@ -33,7 +33,7 @@ fire() {
 	if [ -z "$1" ]; then
 		message="Fire! Branch $(current_branch)."
 	else
-		message="$@"
+		message="$*"
 	fi
 
 	git commit -m "$message"

--- a/git-fire
+++ b/git-fire
@@ -30,7 +30,7 @@ fire() {
 	git checkout -b "$(new_branch)"
 	git add -A
 
-	if [ -z $1 ]; then
+	if [ -z "$1" ]; then
 		message="Fire! Branch $(current_branch)."
 	else
 		message="$@"

--- a/git-fire
+++ b/git-fire
@@ -38,7 +38,7 @@ fire() {
 
 	git commit -m "$message"
 
-	for remote in "$(git remote)"; do
+	for remote in $(git remote); do
 		git push --set-upstream "${remote}" "$(current_branch)" || true
 	done
 

--- a/git-fire
+++ b/git-fire
@@ -4,7 +4,7 @@
 VERSION="0.0.1"
 
 version() {
-	echo "git-fire version $VERSION\n"
+	printf "git-fire version %s\n" "$VERSION"
 
 	git --version
 }
@@ -42,7 +42,7 @@ fire() {
 		git push --set-upstream "${remote}" "$(current_branch)" || true
 	done
 
-	echo "\n\nLeave building!"
+	printf "\n\nLeave building!"
 }
 
 display_help() {

--- a/git-fire
+++ b/git-fire
@@ -27,7 +27,7 @@ new_branch() {
 }
 
 fire() {
-	git checkout -b $(new_branch)
+	git checkout -b "$(new_branch)"
 	git add -A
 
 	if [ -z $1 ]; then


### PR DESCRIPTION
Adjusted the git-fire command to not trigger warnings and errors in shellcheck linter. See shellcheck.net for online tool.
