### PR TITLE
Change to git root directory before adding files

### DIFF
--- a/git-fire
+++ b/git-fire
@@ -28,6 +28,10 @@ new_branch() {
 
 fire() {
 	git checkout -b "$(new_branch)"
+    
+	# cd to git root directory
+	cd $(git rev-parse --show-toplevel)
+
 	git add -A
 
 	if [ -z "$1" ]; then


### PR DESCRIPTION
In the case that the current working directory is not the git root,
and there have been modifications made in directories higher
up the tree than the present working directory, `git add -A` will fail
to add those changes.
Changed the working directory to the git root directory so that
`git add -A` adds all files.
