### PR TITLE
Change current_branch for old git versions support

### DIFF
--- a/git-fire
+++ b/git-fire
@@ -11,7 +11,7 @@ version() {
 
 # Helpers.
 current_branch() {
-	git symbolic-ref --short HEAD
+	basename $(git symbolic-ref HEAD)
 }
 
 current_epoch() {


### PR DESCRIPTION
git-fire currently fails on git version < 1.8 (Tested on 1.7.9), when it tries to get the current branch name.
`error: unknown option short`.
That's because `--short` option wasn't around in git versions < 1.8.

The new branch that is created, it's without the branch-name, like this - 

```
fire--<email>-1444409940
    ^^ The branch-name should have been here
```

This also creates another problem - not pushing to remote.
That is because `current_branch()` is also used in 
`git push --set-upstream ... "$(current_branch)"...`
which fails, due to which `git push` also fails, with the message - 
`Not pushing to remote - "remote part of refspec is not a valid name"`
This PR's current branch fetch is plain `git-symbolic-ref` without options and `basename` cmd that should work for most systems. (It should work as far back as [git 1.6](https://git-scm.com/docs/git-symbolic-ref/1.6.0.2) I think)
