### PR TITLE
Prevent word splitting

### DIFF
--- a/git-fire
+++ b/git-fire
@@ -11,7 +11,7 @@ version() {
 
 # Helpers.
 current_branch() {
-	basename $(git symbolic-ref HEAD)
+	basename "$(git symbolic-ref HEAD)"
 }
 
 current_epoch() {
@@ -30,7 +30,7 @@ fire() {
 	git checkout -b "$(new_branch)"
     
 	# cd to git root directory
-	cd $(git rev-parse --show-toplevel)
+	cd "$(git rev-parse --show-toplevel)"
 
 	git add -A
 


### PR DESCRIPTION
This PR prevents word splitting, e.g. when the repository is stored in a directory named `/hello world/project`.
