### PR TITLE
don't push the stashes if there isn't any

### DIFF
--- a/git-fire
+++ b/git-fire
@@ -48,9 +48,11 @@ fire() {
 		git push --set-upstream "${remote}" "$(current_branch)" || true
 	done
 
-	for sha in $(git rev-list -g stash); do
-		git push origin "$sha":refs/heads/"$(current_branch $initial_branch)"-stash-"$sha"
-	done
+  if [[ $(git stash list) != '' ]]; then
+	  for sha in $(git rev-list -g stash); do
+		  git push origin "$sha":refs/heads/"$(current_branch $initial_branch)"-stash-"$sha"
+	  done
+  fi
 
 	printf "\n\nLeave building!\n"
 }


### PR DESCRIPTION
If you did a `git fire` in a repo without any stash you would get this error:
```
fatal: ambiguous argument 'stash': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```