### PR TITLE
Prevent gpg signing of commits (fixes #30)

### DIFF
--- a/git-fire
+++ b/git-fire
@@ -42,7 +42,14 @@ fire() {
 		message="$*"
 	fi
 
-	git commit -m "$message" --no-verify
+	# for git >= 2.x add the --no-gpg-sign flag
+	if (git version | grep \\s2\.) then
+		nosignflag="--no-gpg-sign"
+	else
+		nosignflag=""
+	fi
+
+	git commit -m "$message" --no-verify $nosignflag
 
 	for remote in $(git remote); do
 		git push --set-upstream "${remote}" "$(current_branch)" || true

--- a/git-fire
+++ b/git-fire
@@ -43,7 +43,7 @@ fire() {
 	fi
 
 	# for git >= 2.x add the --no-gpg-sign flag
-	if (git version | grep \\s2\.) then
+	if git version | grep \\s2\. > /dev/null; then
 		nosignflag="--no-gpg-sign"
 	else
 		nosignflag=""


### PR DESCRIPTION
When using git 2.x and the `commit.gpgsign` option is enabled, each commit is automatically signed with gpg. As noted in #30 this usually means that the user has to enter a password, or unlock the gpg key using some other method. This is a problem when having to leave the building because of fire.

This commit solves the problem by adding the --no-gpg-sign flag to the `git commit` invocation if the git version being used starts with a "2". This is achieved by checking the output of `git version` and using grep to match the version number.