### PR TITLE
Use `[` instead of bash-specific `[[` for test

### DIFF
--- a/git-fire
+++ b/git-fire
@@ -48,7 +48,7 @@ fire() {
 		git push --set-upstream "${remote}" "$(current_branch)" || true
 	done
 
-  if [[ $(git stash list) != '' ]]; then
+  if [ '$(git stash list)' != '' ]; then
 	  for sha in $(git rev-list -g stash); do
 		  git push origin "$sha":refs/heads/"$(current_branch $initial_branch)"-stash-"$sha"
 	  done

--- a/git-fire
+++ b/git-fire
@@ -48,7 +48,7 @@ fire() {
 		git push --set-upstream "${remote}" "$(current_branch)" || true
 	done
 
-  if [ '$(git stash list)' != '' ]; then
+  if [ "$(git stash list)" != '' ]; then
 	  for sha in $(git rev-list -g stash); do
 		  git push origin "$sha":refs/heads/"$(current_branch $initial_branch)"-stash-"$sha"
 	  done


### PR DESCRIPTION
The '[[' test is a `bash`-specific builtin, so on systems where `#!/usr/bin/env sh` (the hashbang line) doesn't return a bash executable, you can get this error:

    /usr/bin/git-fire: 52: /usr/bin/git-fire: [[: not found

In my case the script was running in `dash`, which doesn't have the builtin and [aims for POSIX compliance](https://linux.die.net/man/1/dash) over additional features.

The commit changes the test on line 52 to use [the `[` executable](https://linux.die.net/man/1/test) instead, and adds quotes around the `$( )` expression for escaping.